### PR TITLE
support for wmts layers in TOC

### DIFF
--- a/oliver.php
+++ b/oliver.php
@@ -56,7 +56,7 @@ var moreInfoHTML = '<table border="0" width=100% cellpadding=0 cellspacing=10><t
          ,'OpenStreetMap'
 	 ,'Orthos 2013-2014'
 	 ,'MassGIS Statewide Basemap'
-         ,'Google 2014-2015 Orthoimagery'
+         // ,'Google 2014-2015 Orthoimagery'
        ];
 
 


### PR DESCRIPTION
@MassGIS And here we have support for WMTS in the TOC.

A slight tweak to the folderset entry so that we can piggy back on default tiled_overlay behavior as much as possible.  This is what it should look like.

```
<Layer title="Google 2014-2015 Orthoimagery" style="" name="Google_2014_2015_WMTS" type="tiled_overlay" wmts="true" />
```

I also commented out this layer from the basemap list in the PHP.  I'm not sure if they would clobber or what.

![snag-0076](https://cloud.githubusercontent.com/assets/180985/15373667/c0f8d8fe-1d14-11e6-9b98-718c241f9419.jpg)

I will want to follow this up w/ one final pull request so that I can un-hardwire these WMTS instanced from the 1st entry in our new wmts.js.  You may notice that I have `wmts[0]` in several places.  That's fine for our 1 dataset, but I want it to be flexible.

Also, I am hardwiring any WMTS to 900913.  If that needs to be more flexible, let me know.