### PR TITLE
specify zoom levels for wmts as layer

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -4028,6 +4028,7 @@ function addLayer(wms,proj,title,viz,opacity,url,styles,filter) {
         ,format:    'image/png'
         ,style:     '_null'
         ,projection: 'EPSG:900913'
+        ,numZoomLevels: wmts[0].matrix_ids.length
         ,tileOptions: {
             crossOriginKeyword: null,
             eventListeners: {


### PR DESCRIPTION
@MassGIS A similar fix for normal folderset WMTS to support all zoom levels.