### PR TITLE
fix (again!) the basemap zoom level for WMTS

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -752,6 +752,7 @@ Ext.onReady(function() {
     ,style:       '_null'
     ,attribution: 'Say something nice about me!'
     ,projection:  'EPSG:900913'
+    ,numZoomLevels: wmts[0].matrix_ids.length
   });
 
   for (l in lyrBase) {


### PR DESCRIPTION
@MassGIS This should reapply that fix for the WMTS basemap zoom levels.