### PR TITLE
only numbers, characters, _, ., and - allowed for export filename

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -5872,12 +5872,13 @@ function launchExportWizard(aoi) {
           }
           ,{
              xtype : 'fieldset'
-            ,title : 'Name of the ZIP file to download (do not use spaces)'
+            ,title : 'Name of the ZIP file to download'
             ,items : new Ext.form.TextField({
                name       : 'zipName'
               ,id         : 'zipName'
               ,allowBlank : false
               ,fieldLabel : 'File name'
+              ,maskRe     : /[a-zA-Z0-9|\-|_|\.]+/
             })
           }
         ]


### PR DESCRIPTION
@MassGIS See if this does the trick for filenames.

![snag-0038](https://cloud.githubusercontent.com/assets/180985/15683299/9d1126ba-272f-11e6-9dc1-57ffed0e5920.jpg)
