### PR TITLE
correctly apply incoming URL geocoding for google

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -3499,7 +3499,7 @@ if (!toolSettings || !toolSettings.commentTool || toolSettings.commentTool.statu
     }
     else if (launchSearch.gcType == 'Google' && toolSettings && toolSettings.bingAddressSearch) {
       bingAddressSearch({
-         text         : launchSearch.address
+         text         : typeof launchSearch.address == 'object' ? launchSearch.address.join(' ') : launchSearch.address
         ,zoomToCenter : launchSearch.zoomTo == 'center'
         ,zoomToRegion : launchSearch.zoomTo == 'region'
       });


### PR DESCRIPTION
@MassGIS Easy one.

First off, it's `gcType=Google` on the URL (not bing).

And the code did need a slight tweak.  Also, remember to swap out my key for yours.
